### PR TITLE
Add support for multiple collections on useCollection method

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Set the collections you want to use with the useCollection method
 
 ```javascript
 db.useCollection('users');
+db.useCollection(['users', 'posts']);
 ```
 
 Now you can use the mongodb driver methods

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "imongo",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "",
   "main": "./lib/index.js",
   "files": [

--- a/src/imongo.ts
+++ b/src/imongo.ts
@@ -1,3 +1,4 @@
+/* eslint-disable prettier/prettier */
 import * as mongoDB from 'mongodb';
 
 export class imongo {
@@ -22,9 +23,16 @@ export class imongo {
    * Set the collection you want to use in the imongo instance.
    * @param {string} Collection_name.
    */
-  public useCollection(collection: string): void {
-    const usersCollection: mongoDB.Collection = this.db?.collection(collection);
-    this.collections?.set(collection, usersCollection);
+  public useCollection(collection: string | Array<string>): void {
+    if (typeof collection == 'string') {
+      const _collection: mongoDB.Collection = this.db?.collection(collection);
+      this.collections?.set(collection, _collection);
+    } else {
+      collection.forEach((collection: string) => {
+        const _collection: mongoDB.Collection = this.db?.collection(collection);
+        this.collections?.set(collection, _collection);
+      });
+    }
   }
 
   /**

--- a/src/imongo.ts
+++ b/src/imongo.ts
@@ -28,9 +28,10 @@ export class imongo {
       const _collection: mongoDB.Collection = this.db?.collection(collection);
       this.collections?.set(collection, _collection);
     } else {
-      collection.forEach((collection: string) => {
-        const _collection: mongoDB.Collection = this.db?.collection(collection);
-        this.collections?.set(collection, _collection);
+      collection.forEach((thisCollection: string) => {
+        const _collection: mongoDB.Collection =
+          this.db?.collection(thisCollection);
+        this.collections?.set(thisCollection, _collection);
       });
     }
   }


### PR DESCRIPTION
Proposal:
Old method: `db.useCollection('collection-name');`
New method: `db.useCollection(['collection1', 'collection2']);`

With this PR both methods will work