### PR TITLE
Add init method and chage connect to be paramsless

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ Create the IMongo instance
 const db = new imongo();
 ```
 
-Connect to the database using the connect method
+Init the connection settings and then connect to the database
 
 ```javascript
-await db.connect('url', 'database name');
+await db.init('url', 'database name').connect();
 ```
 
 Call the database method to get a db object if you want to use mongoDB.Db methods

--- a/src/imongo.ts
+++ b/src/imongo.ts
@@ -8,8 +8,8 @@ export class imongo {
     new Map([]);
 
   /**
-   * Set the connection to the database.
-   * @param {string} Conn_url - The MongoDB cluster connection url, don't the database name in the string.
+   * Set the connection params for the MongoCluster and the database.
+   * @param {string} Cluster_url - The MongoDB cluster connection url, the database name is not required.
    * @param {string} Db_name - The MongoDB database name.
    */
   public init(url: string, db: string) {
@@ -18,6 +18,10 @@ export class imongo {
     return this;
   }
 
+  /**
+   * Connect to the MongoDB Cluster and database.
+   * This method is asynchronous.
+   */
   public async connect() {
     await this.client.connect();
     console.log('Connection with MongoDB sucssessful');
@@ -25,7 +29,7 @@ export class imongo {
 
   /**
    * Set the collection you want to use in the imongo instance.
-   * @param {string} Collection_name.
+   * @param {string | Array<string>} Collection_name. The collection name or an array of collections.
    */
   public useCollection(collection: string | Array<string>): void {
     if (typeof collection == 'string') {

--- a/src/imongo.ts
+++ b/src/imongo.ts
@@ -2,8 +2,8 @@
 import * as mongoDB from 'mongodb';
 
 export class imongo {
+  private client!: mongoDB.MongoClient;
   private db!: mongoDB.Db;
-  private dbs: Map<string, mongoDB.Db> = new Map([]);
   private collections: Map<string, mongoDB.Collection<mongoDB.Document>> =
     new Map([]);
 
@@ -12,11 +12,15 @@ export class imongo {
    * @param {string} Conn_url - The MongoDB cluster connection url, don't the database name in the string.
    * @param {string} Db_name - The MongoDB database name.
    */
-  public async connect(url: string, db: string) {
-    const client: mongoDB.MongoClient = new mongoDB.MongoClient(url);
-    await client.connect();
+  public init(url: string, db: string) {
+    this.client = new mongoDB.MongoClient(url);
+    this.db = this.client.db(db);
+    return this;
+  }
+
+  public async connect() {
+    await this.client.connect();
     console.log('Connection with MongoDB sucssessful');
-    this.db = client.db(db);
   }
 
   /**


### PR DESCRIPTION
Old connection method:
`await db.connect('connstring', 'dbname');`

Proposed init and connection method
`await db.init('connstring', 'dbname').connect();` 
or 
`db.init('connstring', 'dbname');
await db.connect();
`

With this new features you can create an instance of imongo in a file and then connect to the database in another file.